### PR TITLE
Add error handling functionality

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -25,7 +25,7 @@ export class App extends Component {
           <Route path="/" exact component={NoteArea} />
           <Route path="/new-note" component={CreateNote} />
           <Route path="/notes/:id" render={this.findNote} />
-          <Route render={(props) => <ErrorDisplay {...props} />}/>
+          <Route render={ErrorDisplay}/>
         </Switch>
       </div>
     );

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
-import { NoteArea, CreateNote } from "../";
-import { withRouter, Route } from "react-router-dom";
+import { NoteArea, CreateNote, ErrorDisplay } from "../";
+import { withRouter, Route, Switch } from "react-router-dom";
 import { connect } from "react-redux";
 import { getNotes } from "../../thunks/";
 import PropTypes from "prop-types";
@@ -20,11 +20,13 @@ export class App extends Component {
   render() {
     return (
       <div className="App">
-        {/*we still need to check for garbage urls */}
-        <Route path="/" exact component={Header} />
-        <Route path="/" exact component={NoteArea} />
-        <Route path="/new-note" component={CreateNote} />
-        <Route path="/notes/:id" render={this.findNote} />
+          <Route path="/" exact component={Header} />
+        <Switch> 
+          <Route path="/" exact component={NoteArea} />
+          <Route path="/new-note" component={CreateNote} />
+          <Route path="/notes/:id" render={this.findNote} />
+          <Route render={(props) => <ErrorDisplay {...props} />}/>
+        </Switch>
       </div>
     );
   }

--- a/src/containers/ErrorDisplay/ErrorDisplay.js
+++ b/src/containers/ErrorDisplay/ErrorDisplay.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { withRouter } from "react-router-dom";
+import { withRouter, NavLink } from "react-router-dom";
 
 export const ErrorDisplay = (props) => {
   return (
@@ -7,6 +7,7 @@ export const ErrorDisplay = (props) => {
       <h2>Error 404</h2>
       <h3>Page not found.</h3>
       <p>The path localhost:/3000{props.location.pathname} was not found.</p>
+      <NavLink to='/'><button>Return Home</button></NavLink>
     </div>
   )
 };

--- a/src/containers/ErrorDisplay/ErrorDisplay.js
+++ b/src/containers/ErrorDisplay/ErrorDisplay.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+export const ErrorDisplay = (props) => {
+  return (
+    <div>
+      <h2>Error 404</h2>
+      <h3>Page not found.</h3>
+      <p>The path localhost:/3000{props.location.pathname} was not found.</p>
+    </div>
+  )
+};
+
+export default withRouter(ErrorDisplay);

--- a/src/containers/ErrorDisplay/ErrorDisplay.test.js
+++ b/src/containers/ErrorDisplay/ErrorDisplay.test.js
@@ -5,7 +5,7 @@ import { ErrorDisplay } from "./ErrorDisplay";
 describe("ErrorDisplay", () => {
   let wrapper;
   it("should render with no error and match snapshot", () => {
-    wrapper = shallow(<ErrorDisplay />);
+    wrapper = shallow(<ErrorDisplay location='path.com' />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/containers/ErrorDisplay/ErrorDisplay.test.js
+++ b/src/containers/ErrorDisplay/ErrorDisplay.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { ErrorDisplay } from "./ErrorDisplay";
+
+describe("ErrorDisplay", () => {
+  let wrapper;
+  it("should render with no error and match snapshot", () => {
+    wrapper = shallow(<ErrorDisplay />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/containers/ErrorDisplay/__snapshots__/ErrorDisplay.test.js.snap
+++ b/src/containers/ErrorDisplay/__snapshots__/ErrorDisplay.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorDisplay should render with no error and match snapshot 1`] = `
+<div>
+  <h2>
+    Error 404
+  </h2>
+  <h3>
+    Page not found.
+  </h3>
+  <p>
+    The path localhost:/3000
+     was not found.
+  </p>
+  <NavLink
+    activeClassName="active"
+    aria-current="page"
+    to="/"
+  >
+    <button>
+      Return Home
+    </button>
+  </NavLink>
+</div>
+`;

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -2,5 +2,6 @@ import NoteCard from "./NoteCard/NoteCard";
 import { NoteItems } from "./NoteItems/NoteItems";
 import NoteArea from "./NoteArea/NoteArea";
 import CreateNote from "./CreateNote/CreateNote";
+import ErrorDisplay from './ErrorDisplay/ErrorDisplay'
 
-export { NoteCard, NoteItems, NoteArea, CreateNote };
+export { NoteCard, NoteItems, NoteArea, CreateNote, ErrorDisplay };


### PR DESCRIPTION
Added error handling as a 404: 

- Created component so that Router could render error properly.
- <Switch> Router component will only render the first matched path (so that the 404 does not show all the time)
- Used the location object from withRouter as a prop to display the invalid path on the DOM in the error component.